### PR TITLE
Initialize classes with sensible defaults

### DIFF
--- a/aibs/eye_tracking/_schemas.py
+++ b/aibs/eye_tracking/_schemas.py
@@ -2,20 +2,22 @@ from argschema import ArgSchema
 from argschema.schemas import DefaultSchema
 from argschema.fields import (Nested, OutputDir, InputFile, Bool, Float, Int,
                               OutputFile, NumpyArray)
+from .eye_tracking import PointGenerator, EyeTracker
+from .fit_ellipse import EllipseFitter
 
 
 class RansacParameters(DefaultSchema):
-    minimum_points_for_fit = Int(default=10,
+    minimum_points_for_fit = Int(default=EllipseFitter.DEFAULT_MINIMUM_POINTS_FOR_FIT,
                                  description=("Number of points required to "
                                               "fit data"))
-    number_of_close_points = Int(default=4,
+    number_of_close_points = Int(default=EllipseFitter.DEFAULT_NUMBER_OF_CLOSE_POINTS,
                                  description=("Number of candidate outliers "
                                               "reselected as inliers required "
                                               "to consider a good fit"))
-    threshold = Float(default=0.0001,
+    threshold = Float(default=EllipseFitter.DEFAULT_THRESHOLD,
                       description=("Error threshold below which data should "
                                    "be considered an inlier"))
-    iterations = Int(default=10,
+    iterations = Int(default=EllipseFitter.DEFAULT_ITERATIONS,
                      description="Number of iterations to run")
 
 
@@ -26,13 +28,13 @@ class AnnotationParameters(DefaultSchema):
 
 
 class StarburstParameters(DefaultSchema):
-    index_length = Int(default=200,
+    index_length = Int(default=PointGenerator.DEFAULT_INDEX_LENGTH,
                        description="Initial default length for rays")
-    n_rays = Int(default=18,
+    n_rays = Int(default=PointGenerator.DEFAULT_N_RAYS,
                  description="Number of rays to draw")
-    threshold_factor = Float(default=1.6,
+    threshold_factor = Float(default=PointGenerator.DEFAULT_THRESHOLD_FACTOR,
                              description="Threshold factor for ellipse edges")
-    threshold_pixels = Int(default=10,
+    threshold_pixels = Int(default=PointGenerator.DEFAULT_THRESHOLD_PIXELS,
                            description=("Number of pixels from start of ray "
                                         "to use for adaptive threshold, "
                                         "also serves as a minimum cutoff for "
@@ -40,27 +42,27 @@ class StarburstParameters(DefaultSchema):
 
 
 class EyeParameters(DefaultSchema):
-    cr_recolor_scale_factor = Float(default=2.0,
+    cr_recolor_scale_factor = Float(default=EyeTracker.DEFAULT_CR_RECOLOR_SCALE_FACTOR,
                                     description=("Size multiplier for corneal "
                                                  "reflection recolor mask"))
-    min_pupil_value = Int(default=0,
+    min_pupil_value = Int(default=EyeTracker.DEFAULT_MIN_PUPIL_VALUE,
                           description=("Minimum value the average pupil shade "
                                        "can be"))
-    max_pupil_value = Int(default=30,
+    max_pupil_value = Int(default=EyeTracker.DEFAULT_MAX_PUPIL_VALUE,
                           description=("Maximum value the average pupil shade "
                                        "can be"))
-    recolor_cr = Bool(default=True,
+    recolor_cr = Bool(default=EyeTracker.DEFAULT_RECOLOR_CR,
                       description="Flag for recoloring corneal reflection")
-    pupil_mask_radius = Int(default=40,
+    pupil_mask_radius = Int(default=EyeTracker.DEFAULT_PUPIL_MASK_RADIUS,
                             description=("Radius of pupil mask used to find "
                                          "seed point"))
-    cr_mask_radius = Int(default=10,
+    cr_mask_radius = Int(default=EyeTracker.DEFAULT_CR_MASK_RADIUS,
                          description=("Radius of cr mask used to find seed "
                                      "point"))
 
 
 class QCParameters(DefaultSchema):
-    generate_plots = Bool(default=False,
+    generate_plots = Bool(default=EyeTracker.DEFAULT_GENERATE_QC_OUTPUT,
                           description=("Flag for whether or not to output QC "
                                        "plots"))
     output_dir = OutputDir(default="./qc",
@@ -75,9 +77,9 @@ class InputParameters(ArgSchema):
     input_source = InputFile(description="Path to input movie",
                              required=True)
     pupil_bounding_box = NumpyArray(dtype="int",
-                                    default=None)
+                                    default=[])
     cr_bounding_box = NumpyArray(dtype="int",
-                                 default=None)
+                                 default=[])
     ransac = Nested(RansacParameters)
     annotation = Nested(AnnotationParameters)
     starburst = Nested(StarburstParameters)

--- a/aibs/eye_tracking/eye_tracking.py
+++ b/aibs/eye_tracking/eye_tracking.py
@@ -9,11 +9,6 @@ from .feature_extraction import (get_circle_mask, max_image_at_value,
 from .plotting import Annotator, ellipse_points
 
 SMOOTHING_KERNEL_SIZE = 3
-DEFAULT_MIN_PUPIL_VALUE = 0
-DEFAULT_MAX_PUPIL_VALUE = 30
-DEFAULT_CR_RECOLOR_SCALE_FACTOR = 2.0
-DEFAULT_CR_MASK_RADIUS = 10
-DEFAULT_PUPIL_MASK_RADIUS = 40
 
 
 class PointGenerator(object):
@@ -34,8 +29,14 @@ class PointGenerator(object):
         Number of pixels (from beginning of ray) to use to determine
         threshold.
     """
-    def __init__(self, index_length, n_rays, threshold_factor,
-                 threshold_pixels):
+    DEFAULT_INDEX_LENGTH = 100
+    DEFAULT_N_RAYS = 20
+    DEFAULT_THRESHOLD_FACTOR = 1.6
+    DEFAULT_THRESHOLD_PIXELS = 10
+    def __init__(self, index_length=DEFAULT_INDEX_LENGTH,
+                 n_rays=DEFAULT_N_RAYS,
+                 threshold_factor=DEFAULT_THRESHOLD_FACTOR,
+                 threshold_pixels=DEFAULT_THRESHOLD_PIXELS):
         self.xs, self.ys = generate_ray_indices(index_length, n_rays)
         self.threshold_pixels = threshold_pixels
         self.threshold_factor = threshold_factor
@@ -175,9 +176,21 @@ class EyeTracker(object):
         cr_recolor_scale_factor : float
         recolor_cr : bool
     """
-    def __init__(self, im_shape, input_stream, output_stream, starburst_params,
-                 ransac_params, pupil_bounding_box=None, cr_bounding_box=None,
-                 generate_QC_output=False, **kwargs):
+    DEFAULT_MIN_PUPIL_VALUE = 0
+    DEFAULT_MAX_PUPIL_VALUE = 30
+    DEFAULT_CR_RECOLOR_SCALE_FACTOR = 2.0
+    DEFAULT_RECOLOR_CR = True
+    DEFAULT_CR_MASK_RADIUS = 10
+    DEFAULT_PUPIL_MASK_RADIUS = 40
+    DEFAULT_GENERATE_QC_OUTPUT = False
+    def __init__(self, im_shape, input_stream, output_stream=None,
+                 starburst_params=None, ransac_params=None,
+                 pupil_bounding_box=None, cr_bounding_box=None,
+                 generate_QC_output=DEFAULT_GENERATE_QC_OUTPUT, **kwargs):
+        if starburst_params is None:
+            starburst_params = {}
+        if ransac_params is None:
+            ransac_params = {}
         self.point_generator = PointGenerator(**starburst_params)
         self.ellipse_fitter = EllipseFitter(**ransac_params)
         self.annotator = Annotator(output_stream)
@@ -202,17 +215,17 @@ class EyeTracker(object):
 
     def _init_kwargs(self, **kwargs):
         self.min_pupil_value = kwargs.get("min_pupil_value",
-                                          DEFAULT_MIN_PUPIL_VALUE)
+                                          self.DEFAULT_MIN_PUPIL_VALUE)
         self.max_pupil_value = kwargs.get("max_pupil_value",
-                                          DEFAULT_MAX_PUPIL_VALUE)
+                                          self.DEFAULT_MAX_PUPIL_VALUE)
         self.last_pupil_color = self.min_pupil_value
         self.cr_recolor_scale_factor = kwargs.get(
-            "cr_recolor_scale_factor", DEFAULT_CR_RECOLOR_SCALE_FACTOR)
-        self.recolor_cr = kwargs.get("recolor_cr", True)
+            "cr_recolor_scale_factor", self.DEFAULT_CR_RECOLOR_SCALE_FACTOR)
+        self.recolor_cr = kwargs.get("recolor_cr", self.DEFAULT_RECOLOR_CR)
         self.cr_mask = get_circle_mask(
-            kwargs.get("cr_mask_radius", DEFAULT_CR_MASK_RADIUS))
+            kwargs.get("cr_mask_radius", self.DEFAULT_CR_MASK_RADIUS))
         self.pupil_mask = get_circle_mask(
-            kwargs.get("pupil_mask_radius", DEFAULT_PUPIL_MASK_RADIUS))
+            kwargs.get("pupil_mask_radius", self.DEFAULT_PUPIL_MASK_RADIUS))
 
     @property
     def mean_frame(self):

--- a/aibs/eye_tracking/fit_ellipse.py
+++ b/aibs/eye_tracking/fit_ellipse.py
@@ -30,8 +30,13 @@ class EllipseFitter(object):
     iterations : int
             Number of iterations to run.
     """
-    def __init__(self, minimum_points_for_fit, number_of_close_points,
-                 threshold, iterations):
+    DEFAULT_MINIMUM_POINTS_FOR_FIT = 10
+    DEFAULT_NUMBER_OF_CLOSE_POINTS = 4
+    DEFAULT_THRESHOLD = 0.0001
+    DEFAULT_ITERATIONS = 10
+    def __init__(self, minimum_points_for_fit=DEFAULT_MINIMUM_POINTS_FOR_FIT,
+                 number_of_close_points=DEFAULT_NUMBER_OF_CLOSE_POINTS,
+                 threshold=DEFAULT_THRESHOLD, iterations=DEFAULT_ITERATIONS):
         self.minimum_points_for_fit = minimum_points_for_fit
         self.number_of_close_points = number_of_close_points
         self.threshold = threshold


### PR DESCRIPTION
Initialize all classes with sensible default values to make them simpler to use. Use the same default values for the input schema.