### PR TITLE
Eye tracking with start/stop/step iteration

### DIFF
--- a/allensdk/eye_tracking/_schemas.py
+++ b/allensdk/eye_tracking/_schemas.py
@@ -110,6 +110,14 @@ class InputParameters(ArgSchema):
         required=True)
     pupil_bounding_box = NumpyArray(dtype="int", default=[])
     cr_bounding_box = NumpyArray(dtype="int", default=[])
+    start_frame = Int(
+        description="Frame of movie to start processing at")
+    stop_frame = Int(
+        description="Frame of movie to end processing at")
+    frame_step = Int(
+        description=("Interval of frames to process. Used for skipping frames,"
+                     "if 1 it will process every frame between start and stop")
+    )
     ransac = Nested(RansacParameters)
     annotation = Nested(AnnotationParameters)
     starburst = Nested(StarburstParameters)

--- a/allensdk/eye_tracking/frame_stream.py
+++ b/allensdk/eye_tracking/frame_stream.py
@@ -21,7 +21,9 @@ class FrameInputStream(object):
             self.process_frame_cb = lambda f: f[:, :, 0].copy()
         self.frames_read = 0
         self.frame_cache = []
-        self.next = self.__next__
+
+    def next(self):
+        return self.__next__()
 
     def __getitem__(self, key):
         if isinstance(key, int) and key >= 0:

--- a/allensdk/eye_tracking/frame_stream.py
+++ b/allensdk/eye_tracking/frame_stream.py
@@ -11,7 +11,7 @@ class FrameInputStream(object):
         self._start = 0
         self._stop = num_frames
         self._step = 1
-        self._i = 0
+        self._i = self._start - self._step
         self._last_i = 0
         self.block_size = block_size
         self.cache_frames = cache_frames
@@ -30,7 +30,7 @@ class FrameInputStream(object):
             self._start = key
             self._stop = key + 1
             self._step = 1
-            return self
+            return list(self)[0]  # force iteration and closing
         elif isinstance(key, slice):
             if key.step == 0:
                 raise ValueError("slice step cannot be 0")
@@ -120,7 +120,6 @@ class CvInputStream(FrameInputStream):
                                             process_frame_cb=process_frame_cb)
         self.cap = None
         self._frame_shape = None
-        self.load_capture_properties()
         self._stop = self.num_frames
 
     @property

--- a/allensdk/eye_tracking/frame_stream.py
+++ b/allensdk/eye_tracking/frame_stream.py
@@ -4,8 +4,7 @@ import cv2
 
 
 class FrameInputStream(object):
-    def __init__(self, movie_path, num_frames=None, block_size=1,
-                 cache_frames=False, process_frame_cb=None):
+    def __init__(self, movie_path, num_frames=None, process_frame_cb=None):
         self.movie_path = movie_path
         self._num_frames = num_frames
         self._start = 0
@@ -13,8 +12,6 @@ class FrameInputStream(object):
         self._step = 1
         self._i = self._start - self._step
         self._last_i = 0
-        self.block_size = block_size
-        self.cache_frames = cache_frames
         if process_frame_cb:
             self.process_frame_cb = process_frame_cb
         else:
@@ -118,12 +115,9 @@ class FrameInputStream(object):
 
 
 class CvInputStream(FrameInputStream):
-    def __init__(self, movie_path, num_frames=None, block_size=1,
-                 cache_frames=False, process_frame_cb=None):
+    def __init__(self, movie_path, num_frames=None, process_frame_cb=None):
         super(CvInputStream, self).__init__(movie_path=movie_path,
                                             num_frames=num_frames,
-                                            block_size=block_size,
-                                            cache_frames=cache_frames,
                                             process_frame_cb=process_frame_cb)
         self.cap = None
         self._frame_shape = None

--- a/allensdk/eye_tracking/frame_stream.py
+++ b/allensdk/eye_tracking/frame_stream.py
@@ -26,9 +26,14 @@ class FrameInputStream(object):
         return self.__next__()
 
     def __getitem__(self, key):
-        if isinstance(key, int) and key >= 0:
-            self._start = key
-            self._stop = key + 1
+        if isinstance(key, int):
+            if key >= self.num_frames or key < -self.num_frames:
+                raise IndexError("Index {} out of range".format(key))
+            elif key >= 0:
+                self._start = key
+            else:
+                self._start = self.num_frames + key
+            self._stop = self._start + 1
             self._step = 1
             return list(self)[0]  # force iteration and closing
         elif isinstance(key, slice):

--- a/allensdk/eye_tracking/frame_stream.py
+++ b/allensdk/eye_tracking/frame_stream.py
@@ -1,15 +1,18 @@
 import logging
-import os
-import imageio
 import traceback
 import cv2
 
 
 class FrameInputStream(object):
-    def __init__(self, movie_path, num_frames=None, block_size=1,
+    def __init__(self, movie_path, num_frames=0, block_size=1,
                  cache_frames=False, process_frame_cb=None):
         self.movie_path = movie_path
         self._num_frames = num_frames
+        self._start = 0
+        self._stop = num_frames
+        self._step = 1
+        self._i = 0
+        self._last_i = 0
         self.block_size = block_size
         self.cache_frames = cache_frames
         if process_frame_cb:
@@ -18,6 +21,28 @@ class FrameInputStream(object):
             self.process_frame_cb = lambda f: f[:, :, 0].copy()
         self.frames_read = 0
         self.frame_cache = []
+
+    def __getitem__(self, key):
+        if isinstance(key, int) and key >= 0:
+            self._start = key
+            self._stop = key + 1
+            self._step = 1
+            return self
+        elif isinstance(key, slice):
+            if key.step == 0:
+                raise ValueError("slice step cannot be 0")
+            self._start = key.start if key.start is not None else 0
+            if key.stop is None:
+                self._stop = self.num_frames
+            elif key.stop < 0:
+                self._stop = max(self.num_frames + key.stop, -1)
+            else:
+                self._stop = min(self.num_frames, key.stop)
+            self._step = key.step if key.step is not None else 1
+            return self
+        else:
+            raise KeyError("Key must be non-negative integer or slice, not {}"
+                           .format(key))
 
     @property
     def num_frames(self):
@@ -34,59 +59,46 @@ class FrameInputStream(object):
     def close(self):
         logging.debug("Read total frames %d", self.frames_read)
 
-        if self.num_frames is not None and self.frames_read != self.num_frames:
-            raise IOError("read incorrect number of frames: %d vs %d",
-                          self.frames_read, self.num_frames)
-
     def _error(self):
         pass
 
-    def _process_frame(self, frame):
-        return self.process_frame_cb(frame)
+    def _seek_frame(self, i):
+        raise NotImplementedError(("_seek_frame must be implemented in a "
+                                   "subclass"))
 
-    def _read_iter(self):
-        pass
+    def _get_frame(self, i):
+        raise NotImplementedError(("_get_frame must be implemented in a "
+                                   "subclass"))
+
+    def get_frame(self, i):
+        if abs(i - self._last_i) > 1:
+            self._seek_frame(i)
+        self._last_i = self._i
+        self._i = i
+        self.frames_read += 1
+        if self.frames_read % 100 == 0:
+            logging.debug("Read frames %d", self.frames_read)
+        return self.process_frame_cb(self._get_frame(self._i))
 
     def __enter__(self):
         return self
 
     def __iter__(self):
-        # if we're caching frames and the cache exists, return it
-        if self.cache_frames and self.frame_cache:
-            cache_len = len(self.frame_cache)
-            n = self.num_frames if self.num_frames is not None else cache_len
-            for i in range(n):
-                yield self.frame_cache[i]
-        else:
-            self.open()
+        self._last_i = 0
+        self._i = self._start - self._step
+        self.open()
+        logging.debug("Iterating over %s from %d to %d by step %d" %
+                      (self.movie_path, self._start, self._stop, self._step))
+        return self
 
-            self.frame_cache = []
-
-            for frame in self._read_iter():
-                self.frame_cache.append(self._process_frame(frame))
-                self.frames_read += 1
-
-                if (self.frames_read % 100) == 0:
-                    logging.debug("Read frames %d", self.frames_read)
-
-                if self.block_size is None:
-                    continue
-                if self.block_size == 1:
-                    yield self.frame_cache[-1]
-                elif (self.frames_read % self.block_size) == 0:
-                    for i in range(-self.block_size, 0):
-                        yield self.frame_cache[i]
-
-                if not self.cache_frames:
-                    self.frame_cache = []
-
+    def __next__(self):
+        self._i = self._i + self._step
+        if (self._step < 0 and self._i <= self._stop) or \
+           (self._step > 0 and self._i >= self._stop):
             self.close()
-
-            for frame in self.frame_cache:
-                yield frame
-
-            if not self.cache_frames:
-                self.frame_cache = []
+            raise StopIteration()
+        else:
+            return self.get_frame(self._i)
 
     def __exit__(self, exc_type, exc_value, tb):
         if exc_value:
@@ -94,27 +106,25 @@ class FrameInputStream(object):
             self._error()
             raise exc_value
 
-    def create_images(self, output_directory, image_type):
-        for i, frame in enumerate(self):
-            file_name = os.path.join(output_directory,
-                                     "input_frame-%06d." % i + image_type)
-            imageio.imwrite(file_name, frame)
-
 
 class CvInputStream(FrameInputStream):
     def __init__(self, movie_path, num_frames=None, block_size=1,
-                 cache_frames=False):
+                 cache_frames=False, process_frame_cb=None):
         super(CvInputStream, self).__init__(movie_path=movie_path,
                                             num_frames=num_frames,
                                             block_size=block_size,
-                                            cache_frames=cache_frames)
+                                            cache_frames=cache_frames,
+                                            process_frame_cb=process_frame_cb)
         self.cap = None
         self._frame_shape = None
+        self.load_capture_properties()
+        self._stop = self.num_frames
 
     @property
     def num_frames(self):
         if self._num_frames is None:
             self.load_capture_properties()
+            self._stop = self._num_frames
         return self._num_frames
 
     @property
@@ -155,16 +165,14 @@ class CvInputStream(FrameInputStream):
 
         super(CvInputStream, self).close()
 
-    def _read_iter(self):
+    def _seek_frame(self, i):
+        self.cap.set(cv2.CAP_PROP_POS_FRAMES, i)
+
+    def _get_frame(self, i):
         if self.cap is None:
             raise IOError("capture is not open")
-
-        while self.cap.isOpened():
-            ret, frame = self.cap.read()
-            yield frame
-
-            if self.frames_read == self.num_frames:
-                break
+        ret, frame = self.cap.read()
+        return frame
 
     def _error(self):
         self.cap.release()

--- a/allensdk/eye_tracking/frame_stream.py
+++ b/allensdk/eye_tracking/frame_stream.py
@@ -21,6 +21,7 @@ class FrameInputStream(object):
             self.process_frame_cb = lambda f: f[:, :, 0].copy()
         self.frames_read = 0
         self.frame_cache = []
+        self.next = self.__next__
 
     def __getitem__(self, key):
         if isinstance(key, int) and key >= 0:

--- a/test/test_fit_ellipse.py
+++ b/test/test_fit_ellipse.py
@@ -1,6 +1,7 @@
 from allensdk.eye_tracking import fit_ellipse as fe
 import numpy as np
 import pytest
+from mock import patch
 
 
 def rotate_vector(y, x, theta):
@@ -34,6 +35,9 @@ def test_ellipse_fit(a, b, x0, y0, rotation):
     assert(np.abs(angle - np.degrees(rotation)) < 0.01)
     assert((np.abs(ax1-a) < 0.0001 and np.abs(ax2-b) < 0.0001) or
            (np.abs(ax1-b) < 0.0001 and np.abs(ax2-a) < 0.0001))
+    with patch.object(fitter._fitter, "fit", return_value=None):
+        res = fitter.fit(data)
+        assert(np.all(np.isnan(res)))
 
 
 @pytest.mark.parametrize("point,ellipse_params,tolerance,result", [

--- a/test/test_frame_stream.py
+++ b/test/test_frame_stream.py
@@ -38,8 +38,6 @@ def outfile(tmpdir_factory):
 def test_frame_input_init():
     istream = fs.FrameInputStream("test_path")
     assert(istream.movie_path == "test_path")
-    assert(istream.block_size == 1)
-    assert(not istream.cache_frames)
     assert(istream.num_frames == 0)
     with pytest.raises(NotImplementedError):
         istream.frame_shape


### PR DESCRIPTION
Resolves #26 by doing the following:

- Make FrameInputStream and CvInputStream sliceable iterators with efficient handling of frame skips for CvInputStream.
- Update EyeTracker.process_stream to take start, stop, step values. Remove n_frames argument from process_stream.
- Expose start, stop, step values in schema so they can be used by entry point.