### PR TITLE
Fix minimal initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ install:
   - conda create -q -n test-environment python=$TEST_PYTHON_VERSION pip
   - source activate test-environment
   - conda install -c conda-forge xvfbwrapper
-  - conda install pyqt
   - conda install -c conda-forge opencv
+  - conda install -c conda-forge pyqt
   - pip install codecov
   - pip install -r test_requirements.txt
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ install:
   - conda install pyqt
   - conda install -c conda-forge opencv
   - pip install codecov
-  - pip install -r requirements_dev.txt
   - pip install -r test_requirements.txt
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       pip install pytest-xvfb;

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
   - conda create -q -n test-environment python=$TEST_PYTHON_VERSION pip
   - source activate test-environment
   - conda install -c conda-forge xvfbwrapper
+  - conda install pyqt
   - conda install -c conda-forge opencv
   - pip install codecov
   - pip install -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ install:
   - conda create -q -n test-environment python=$TEST_PYTHON_VERSION pip
   - source activate test-environment
   - conda install -c conda-forge xvfbwrapper
-  - conda install pyqt
   - conda install -c conda-forge opencv
   - pip install codecov
   - pip install -r test_requirements.txt

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ have bindary distributions for all platforms yet. The simplest way to
 install these difficult dependencies is to use conda:
 
     conda install scikit-image
-    conda install pyqt
     conda install -c conda-forge opencv
+    conda install -c conda-forge pyqt
 
 The rest of the dependencies are all in the requirements, so to
 install just clone or download the repository and then from inside the

--- a/allensdk/eye_tracking/__main__.py
+++ b/allensdk/eye_tracking/__main__.py
@@ -10,8 +10,8 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     matplotlib.use("Agg")
 from matplotlib import pyplot as plt  # noqa: E402
-from ._schemas import InputParameters, OutputParameters  # noqa: E402
-from .eye_tracking import EyeTracker  # noqa: E402
+from ._schemas import (InputParameters, OutputParameters, DEFAULT_ANNOTATION)  # noqa: E402 E501
+from .eye_tracking import EyeTracker, PointGenerator  # noqa: E402
 from .frame_stream import CvInputStream, CvOutputStream  # noqa: E402
 from .plotting import (plot_summary, plot_cumulative,
                        annotate_with_box, plot_timeseries)  # noqa: E402
@@ -44,7 +44,7 @@ def write_output(output_dir, cr_parameters, pupil_parameters, mean_frame):
 def write_QC_output(annotator, cr_parameters, pupil_parameters,
                     cr_errors, pupil_errors, mean_frame, pupil_intensity=None,
                     **kwargs):
-    output_dir = kwargs["qc"]["output_dir"]
+    output_dir = kwargs.get("qc", {}).get("output_dir", kwargs["output_dir"])
     annotator.annotate_with_cumulative_cr(
         mean_frame, os.path.join(output_dir, "cr_all.png"))
     annotator.annotate_with_cumulative_pupil(
@@ -73,8 +73,10 @@ def write_QC_output(annotator, cr_parameters, pupil_parameters,
 
 def get_starburst_args(kwargs):
     starburst_args = kwargs.copy()
-    threshold_factor = starburst_args.pop("threshold_factor", None)
-    threshold_pixels = starburst_args.pop("threshold_pixels", None)
+    threshold_factor = starburst_args.pop(
+        "threshold_factor", PointGenerator.DEFAULT_THRESHOLD_FACTOR)
+    threshold_pixels = starburst_args.pop(
+        "threshold_pixels", PointGenerator.DEFAULT_THRESHOLD_PIXELS)
 
     if starburst_args.get("cr_threshold_factor", None) is None:
         starburst_args["cr_threshold_factor"] = threshold_factor
@@ -95,21 +97,26 @@ def main():
         mod = ArgSchemaParser(schema_type=InputParameters,
                               output_schema_type=OutputParameters)
 
-        starburst_args = get_starburst_args(mod.args["starburst"])
+        starburst_args = get_starburst_args(mod.args.get("starburst", {}))
 
         istream = CvInputStream(mod.args["input_source"])
 
         ostream = setup_annotation(istream.frame_shape,
-                                   **mod.args["annotation"])
+                                   **mod.args.get("annotation",
+                                                  DEFAULT_ANNOTATION))
+
+        qc_params = mod.args.get("qc", {})
+        generate_plots = qc_params.get(
+            "generate_plots", EyeTracker.DEFAULT_GENERATE_QC_OUTPUT)
 
         tracker = EyeTracker(istream,
                              ostream,
                              starburst_args,
-                             mod.args["ransac"],
+                             mod.args.get("ransac", {}),
                              mod.args["pupil_bounding_box"],
                              mod.args["cr_bounding_box"],
-                             mod.args["qc"]["generate_plots"],
-                             **mod.args["eye_params"])
+                             generate_plots,
+                             **mod.args.get("eye_params", {}))
         cr_params, pupil_params, cr_err, pupil_err = tracker.process_stream(
             start=mod.args.get("start_frame", 0),
             stop=mod.args.get("stop_frame", None),
@@ -122,7 +129,7 @@ def main():
         pupil_intensity = None
         if tracker.adaptive_pupil:
             pupil_intensity = tracker.pupil_colors
-        if mod.args["qc"]["generate_plots"]:
+        if generate_plots:
             write_QC_output(tracker.annotator, cr_params, pupil_params,
                             cr_err, pupil_err, tracker.mean_frame,
                             pupil_intensity=pupil_intensity, **mod.args)

--- a/allensdk/eye_tracking/_schemas.py
+++ b/allensdk/eye_tracking/_schemas.py
@@ -5,6 +5,9 @@ from argschema.fields import (Nested, OutputDir, InputFile, Bool, Float, Int,
 from .eye_tracking import PointGenerator, EyeTracker
 from .fit_ellipse import EllipseFitter
 
+DEFAULT_ANNOTATION = {"annotate_movie": False,
+                      "output_file": "./annotated.avi"}
+
 
 class RansacParameters(DefaultSchema):
     minimum_points_for_fit = Int(
@@ -25,9 +28,9 @@ class RansacParameters(DefaultSchema):
 
 class AnnotationParameters(DefaultSchema):
     annotate_movie = Bool(
-        default=False,
+        default=DEFAULT_ANNOTATION["annotate_movie"],
         description="Flag for whether or not to annotate")
-    output_file = OutputFile(default="./annotated.avi")
+    output_file = OutputFile(default=DEFAULT_ANNOTATION["output_file"])
     fourcc = Str(description=("FOURCC string for video encoding. On Windows "
                               "H264 is not available by default, so it will "
                               "need to be installed or a different codec "
@@ -112,7 +115,7 @@ class QCParameters(DefaultSchema):
         default=EyeTracker.DEFAULT_GENERATE_QC_OUTPUT,
         description="Flag for whether or not to output QC plots")
     output_dir = OutputDir(
-        default="./qc",
+        default="./",
         description="Folder to store QC outputs")
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ install:
   - conda install -c conda-forge opencv
   - conda install pyqt
   - if %PYTHON% == 2.7 conda install scikit-image
-  - pip install -r requirements_dev.txt
   - pip install -r test_requirements.txt
   - pip install .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,8 @@ install:
   - conda update -q conda
   - conda create -q -n test-environment python=%PYTHON% pip
   - activate test-environment
-  - conda install -c conda-forge opencv
-  - conda install pyqt
   - if %PYTHON% == 2.7 conda install scikit-image
+  - conda install -c conda-forge opencv
   - pip install -r test_requirements.txt
   - pip install .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ install:
   - conda create -q -n test-environment python=%PYTHON% pip
   - activate test-environment
   - if %PYTHON% == 2.7 conda install scikit-image
+  - conda install pyqt
   - conda install -c conda-forge opencv
   - pip install -r test_requirements.txt
   - pip install .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ install:
   - conda create -q -n test-environment python=%PYTHON% pip
   - activate test-environment
   - if %PYTHON% == 2.7 conda install scikit-image
-  - conda install pyqt
   - conda install -c conda-forge opencv
+  - conda install -c conda-forge pyqt
   - pip install -r test_requirements.txt
   - pip install .
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,8 +12,8 @@ have bindary distributions for all platforms yet. The simplest way to
 install these difficult dependencies is to use conda::
 
     conda install scikit-image
-    conda install pyqt
     conda install -c conda-forge opencv
+    conda install -c conda-forge pyqt
 
 The rest of the dependencies are all in the requirements, so to install
 just clone or download the repository and then from inside the top

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -99,11 +99,20 @@ def assert_output(output_dir, annotation_file=None, qc_output_dir=None,
         assert(os.path.exists(os.path.join(output_dir, "cr_all.png")))
 
 
+def test_main_valid(input_source, input_json, tmpdir_factory):
+    output_dir = str(tmpdir_factory.mktemp("output"))
+    args = ["allensdk.eye_tracking", "--output_dir", output_dir,
+            "--input_source", input_source]
+    with mock.patch('sys.argv', args):
+        __main__.main()
+        assert_output(output_dir)
+
+
 @pytest.mark.parametrize("pupil_bbox_str,cr_bbox_str, adaptive_pupil", [
     ("[20,50,40,70]", "[40,70,20,50]", True),
     ("[]", "[]", False)
 ])
-def test_main_valid(input_source, input_json, pupil_bbox_str, cr_bbox_str,
+def test_main_valid_json(input_source, input_json, pupil_bbox_str, cr_bbox_str,
                     adaptive_pupil):
     args = ["allensdk.eye_tracking", "--input_json", input_json,
             "--input_source", input_source]

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -113,7 +113,7 @@ def test_main_valid(input_source, input_json, tmpdir_factory):
     ("[]", "[]", False)
 ])
 def test_main_valid_json(input_source, input_json, pupil_bbox_str, cr_bbox_str,
-                    adaptive_pupil):
+                         adaptive_pupil):
     args = ["allensdk.eye_tracking", "--input_json", input_json,
             "--input_source", input_source]
     with open(input_json, "r") as f:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+coverage>=4.1
 pytest>=2.9.2
 mock
 pytest-qt


### PR DESCRIPTION
Fixes #38. At some point running with just --input_source was broken and we didn't have a test to cover it. Even though defaults are provided within the nested schemas, argschema does not supply them if no entries are provided. This PR works around that limitation of argschema and provides default values to allow running with the minimum intended initialization.